### PR TITLE
Added visibility observer

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,6 +181,11 @@ the
           <dd>This specification defines an archival format for HTTP
             transactions that can be used by a web browser to export detailed
             performance data about web pages it loads.</dd>
+          <dt>Visibility Observer</dt>
+          <dd>An interoperable means for site developers to get timing information
+           regarding the visibility of various elements in the page.
+           This will enable developers to get a better notion of the perceived
+           performance their users experience.</dd>
         </dl>
         <p>
 	  In addition, the Working Group will review the


### PR DESCRIPTION
During the Velocity summit there were multiple requests by large Web sites to be able to better track performance by being able to tell when certain elements have been laid out by the browser.
