### PR TITLE
Replace prerender with resource hints and added preload

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,10 +166,14 @@ the
           <dd>An interoperable means for site developers to get web browser
             diagnostics information on their web applications, like error
             logging and memory leaks type information.</dd>
-          <dt>Pre-render (link rel=prerender)</dt>
+          <dt><a href="https://w3c.github.io/resource-hints/">Resource Hints</a></dt>
           <dd>An interoperable means for site developers to instruct the web
-            browser to preload a web page while keeping it hidden to improve
-            user perceived performance.</dd>
+           browser to preconnect, prefetch or prerender certain hosts, resources or Web pages, 
+           in order to improve the performance of either current navigation or future ones.</dd>
+          <dt><a href="https://w3c.github.io/preload/">Preload</a></dt>
+          <dd>An interoperable means for site developers to instruct the web
+           browser to preload a certain resource that will be required later on in current navigation,
+           in order to improve current navigation performance.</dd>
           <dt>Display Performance</dt>
           <dd>An interoperable means for site developers to get frame rate and
             throughput of the display type of information.</dd>


### PR DESCRIPTION
I believe resource hints and preload weren't part of the charter due to omission.
