### PR TITLE
Nominating Yoav Weiss as co-chair of the group

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,6 +108,7 @@
             <td>
               Ilya Grigorik, Google
             <br>Todd Reifsteck, Microsoft
+            <br>Yoav Weiss, Akamai
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
As the title says, I would like to nominate @yoavweiss as a co-chair of the group. 

Yoav has been an active participant in the webperf group for many years, spec editor (Preload, Resource Timing, etc), and implementer (Blink and Webkit) of various perf primitives. 

As we're discussing the new charter, Yoav also expressed willingness to step up and help with the operational aspects of the group which, speaking on my behalf, would be a great and welcome help.

/cc @rniwa @past @tdresser 